### PR TITLE
Remove skipFocus flag

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -112,7 +112,7 @@
         var focus = () => {
           focusElement.dispatchEvent(new CustomEvent('focus'));
         };
-        
+
         var blur = () => {
           focusElement.dispatchEvent(new CustomEvent('blur'));
         };
@@ -152,6 +152,15 @@
           expect(customElement.hasAttribute('focus-ring')).to.be.true;
           blur();
           expect(customElement.hasAttribute('focus-ring')).to.be.false;
+        });
+
+        it('should refocus the field', () => {
+          customElement.dispatchEvent(new CustomEvent('focus'));
+          MockInteractions.keyDownOn(customElement, 9, 'shift');
+
+          var spy = sinon.spy(focusElement, 'focus');
+          customElement.dispatchEvent(new CustomEvent('focus'));
+          expect(spy.called).to.be.true;
         });
       });
 

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -87,7 +87,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
       this.addEventListener('keydown', e => {
         if (e.shiftKey && e.keyCode === 9) {
-          this._skipFocus = !!window.ShadyDOM;
           this.focus();
         }
       });
@@ -143,11 +142,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _focus(e) {
       this._setFocused(!this.disabled);
-
-      if (this._skipFocus) {
-        this._skipFocus = false;
-        return;
-      }
       this.focusElement.focus();
     }
 


### PR DESCRIPTION
They updated webcomponentsjs polyfill so that this hack is no longer needed

Fixes https://github.com/vaadin/vaadin-text-field/issues/71

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/3)
<!-- Reviewable:end -->
