### PR TITLE
Do not listen focus and blur events on focusElement

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -88,33 +88,13 @@
         });
       });
 
-      if (!window.ShadyDOM) {
-        describe('focus', () => {
-          it('should focus the internal input on focus', () => {
-            focusElement.focus();
-            expect(customElement.focused).to.be.true;
-          });
-
-          it('should blur the internal input on blur', () => {
-            customElement.focus();
-            focusElement.blur();
-            expect(customElement.focused).to.be.false;
-          });
-
-          it('should focus the internal input on host click', () => {
-            customElement.click();
-            expect(customElement.focused).to.be.true;
-          });
-        });
-      }
-
       describe('_tabPressed and focus-ring', () => {
         var focus = () => {
-          focusElement.dispatchEvent(new CustomEvent('focus'));
+          customElement.dispatchEvent(new CustomEvent('focus'));
         };
 
         var blur = () => {
-          focusElement.dispatchEvent(new CustomEvent('blur'));
+          customElement.dispatchEvent(new CustomEvent('blur'));
         };
 
         it('should set and unset _tabPressed when press TAB', () => {
@@ -180,7 +160,12 @@
         });
       });
 
-      describe('autofocus', () => {
+      describe('focus and autofocus', () => {
+        it('should set focused attribute on host click', () => {
+          customElement.click();
+          expect(customElement.focused).to.be.true;
+        });
+
         it('should have focused set', done => {
           customElement = fixture('autofocus');
 

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -77,10 +77,8 @@ This program is available under Apache License Version 2.0, available at https:/
     ready() {
       super.ready();
 
-      this.focusElement.addEventListener('focus', () => this._setFocused(true));
       this.addEventListener('focus', e => this._focus(e));
 
-      this.focusElement.addEventListener('blur', () => this._setFocused(false));
       this.addEventListener('blur', () => this._setFocused(false));
 
       this.addEventListener('click', e => this._focus(e));


### PR DESCRIPTION
Fixes #5 

This was an issue in webcomponentsjs. `focus` and `blur` event were not bubbled to parent: https://github.com/webcomponents/shadydom/issues/124

The issue is fixed now and we can skip listening `focus` and `blur` on `focusElement` which is for example the native input for the `text-field`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/6)
<!-- Reviewable:end -->
