### PR TITLE
Overriding of the native focus

### DIFF
--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -144,6 +144,14 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /**
+     * Moving the focus from the host element causes firing of the blur event what leads to problems in IE.
+     * @private
+     */
+    focus() {
+      this.focusElement.focus();
+    }
+
+    /**
      * Native bluring in the host element does nothing because it does not have the focus.
      * In chrome it works, but not in FF.
      * @private


### PR DESCRIPTION
Fixing the bug with firing of the blur event while moving the focus in IE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/7)
<!-- Reviewable:end -->
