### PR TITLE
Aria-disabled attribute, fix disabled focusing issue

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -82,6 +82,25 @@
           expect(customElement.getAttribute('tabindex')).to.not.be.ok;
         });
 
+        it('setting disabled to true and then back to false should restore the previous value of tabindex', () => {
+          customElement.tabIndex = 2;
+          customElement.disabled = true;
+          expect(customElement.getAttribute('tabindex')).to.not.be.ok;
+
+          customElement.disabled = false;
+          expect(customElement.getAttribute('tabindex')).to.be.equal('2');
+        });
+
+        it('new tabindex value that was set while element is disabled should be applied once it becomes enabled', () => {
+          customElement.tabIndex = 2;
+          customElement.disabled = true;
+          customElement.tabIndex = 3;
+          expect(customElement.getAttribute('tabindex')).to.not.be.ok;
+
+          customElement.disabled = false;
+          expect(customElement.getAttribute('tabindex')).to.be.equal('3');
+        });
+
         it('should synchronize tabindex with tabIndex', () => {
           customElement.tabindex = 1;
           expect(customElement.tabIndex).to.eql(1);
@@ -161,6 +180,17 @@
           customElement.tabIndex = 4;
           expect(customElement.getAttribute('tabindex')).to.be.null;
           expect(focusElement.getAttribute('tabindex')).to.be.equal('4');
+        });
+
+        it('should have aria-disabled attribute set to true when disabled', () => {
+          customElement.disabled = true;
+          expect(customElement.getAttribute('aria-disabled')).to.be.equal('true');
+        });
+
+        it('should not have aria-disabled attribute when is not disabled', () => {
+          customElement.disabled = true;
+          customElement.disabled = false;
+          expect(customElement.getAttribute('aria-disabled')).to.not.be.ok;
         });
       });
 

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -64,6 +64,13 @@ This program is available under Apache License Version 2.0, available at https:/
         },
 
         /**
+         * Stores the previous value of tabindex attribute of the disabled element
+         */
+        _previousTabIndex: {
+          type: Number
+        },
+
+        /**
          * If true, the user cannot interact with this element.
          */
         disabled: {
@@ -175,9 +182,12 @@ This program is available under Apache License Version 2.0, available at https:/
       if (disabled) {
         this._setFocused(false);
         this.blur();
-        this.tabindex = undefined;
+        this._previousTabIndex = this.getAttribute('tabindex');
+        this.tabindex = -1;
+        this.setAttribute('aria-disabled', 'true');
       } else {
-        this.tabindex = this.focusElement.tabIndex;
+        this.tabindex = this._previousTabIndex;
+        this.removeAttribute('aria-disabled');
       }
     }
 
@@ -187,6 +197,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       if (this.disabled && this.tabindex) {
+        // If tabindex attribute was changed while checkbox was disabled
+        if (this.tabindex !== -1) {
+          this._previousTabIndex = this.tabindex;
+        }
         this.tabindex = tabindex = undefined;
       }
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-checkbox/issues/7

Add `aria-disabled` attribute, fix issue of focusing disabled elements, saving and restoring the previous value of `tabindex` attribute, tests added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/12)
<!-- Reviewable:end -->
