### PR TITLE
Do not use _previousTabIndex is it wasn't defined

### DIFF
--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -182,11 +182,13 @@ This program is available under Apache License Version 2.0, available at https:/
       if (disabled) {
         this._setFocused(false);
         this.blur();
-        this._previousTabIndex = this.getAttribute('tabindex');
+        this._previousTabIndex = this.tabindex;
         this.tabindex = -1;
         this.setAttribute('aria-disabled', 'true');
       } else {
-        this.tabindex = this._previousTabIndex;
+        if (typeof this._previousTabIndex !== 'undefined') {
+          this.tabindex = this._previousTabIndex;
+        }
         this.removeAttribute('aria-disabled');
       }
     }


### PR DESCRIPTION
Fixes #13 

Unfortunately, I'm not able to prove the issue on the `control-state-mixin` side with a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/14)
<!-- Reviewable:end -->
