### PR TITLE
Handle only focus events from keyboard to prevent focusing element twice

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -208,6 +208,13 @@
             done();
           });
         });
+
+        it('should focus an element only once on click', () => {
+          customElement._focus = sinon.spy();
+          customElement.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+          customElement.dispatchEvent(new CustomEvent('focus', {bubbles: true, composed: true}));
+          expect(customElement._focus.callCount).to.eql(1);
+        });
       });
     });
   </script>

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -86,7 +86,11 @@ This program is available under Apache License Version 2.0, available at https:/
     ready() {
       super.ready();
 
-      this.addEventListener('focus', e => this._focus(e));
+      this.addEventListener('focus', e => {
+        if (this._tabPressed) {
+          this._focus(e);
+        }
+      });
 
       this.addEventListener('blur', () => this._setFocused(false));
 


### PR DESCRIPTION
We don't need to handle the `focus` events generated by mouse as those are handled in click listener: https://github.com/vaadin/vaadin-control-state-mixin/blob/master/vaadin-control-state-mixin.html#L93

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/16)
<!-- Reviewable:end -->
