### PR TITLE
Add focusin, focusout events, controlling focused property

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -108,11 +108,11 @@
       });
 
       describe('_tabPressed and focus-ring', () => {
-        var focus = () => {
+        var focusin = () => {
           focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
         };
 
-        var blur = () => {
+        var focusout = () => {
           focusElement.dispatchEvent(new CustomEvent('focusout', {composed: true, bubbles: true}));
         };
 
@@ -139,17 +139,17 @@
 
         it('should set the focus-ring attribute when TAB is pressed and focus is received', () => {
           MockInteractions.keyDownOn(document.body, 9);
-          focus();
+          focusin();
           expect(customElement.hasAttribute('focus-ring')).to.be.true;
-          blur();
+          focusout();
           expect(customElement.hasAttribute('focus-ring')).to.be.false;
         });
 
         it('should set the focus-ring attribute when SHIFT+TAB is pressed and focus is received', () => {
           MockInteractions.keyDownOn(document.body, 9, 'shift');
-          focus();
+          focusin();
           expect(customElement.hasAttribute('focus-ring')).to.be.true;
-          blur();
+          focusout();
           expect(customElement.hasAttribute('focus-ring')).to.be.false;
         });
 
@@ -197,7 +197,7 @@
       describe('focus and autofocus', () => {
         it('should not set focused attribute on host click', () => {
           customElement.click();
-          expect(customElement.focused).to.be.equal(false);
+          expect(customElement.focused).to.be.false;
         });
 
         it('should set focused attribute on host mousedown', () => {
@@ -213,7 +213,7 @@
 
           customElement.$.input.dispatchEvent(e);
 
-          expect(customElement.focused).to.be.equal(false);
+          expect(customElement.focused).to.be.false;
 
           customElement.$.input.removeEventListener('mousedown', preventDefaultListener);
         });

--- a/test/control-state.html
+++ b/test/control-state.html
@@ -200,8 +200,7 @@
           expect(customElement.focused).to.be.false;
         });
 
-        it('should set focused attribute on host mousedown', () => {
-          customElement.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
+        it('should set focused attribute on focusin event dispatched', () => {
           focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
           expect(customElement.focused).to.be.true;
         });

--- a/test/control-state.html
+++ b/test/control-state.html
@@ -109,11 +109,11 @@
 
       describe('_tabPressed and focus-ring', () => {
         var focus = () => {
-          customElement.dispatchEvent(new CustomEvent('focus'));
+          focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
         };
 
         var blur = () => {
-          customElement.dispatchEvent(new CustomEvent('blur'));
+          focusElement.dispatchEvent(new CustomEvent('focusout', {composed: true, bubbles: true}));
         };
 
         it('should set and unset _tabPressed when press TAB', () => {
@@ -197,11 +197,12 @@
       describe('focus and autofocus', () => {
         it('should not set focused attribute on host click', () => {
           customElement.click();
-          expect(customElement.focused).to.be.undefined;
+          expect(customElement.focused).to.be.equal(false);
         });
 
         it('should set focused attribute on host mousedown', () => {
           customElement.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
+          focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
           expect(customElement.focused).to.be.true;
         });
 
@@ -212,7 +213,7 @@
 
           customElement.$.input.dispatchEvent(e);
 
-          expect(customElement.focused).to.be.undefined;
+          expect(customElement.focused).to.be.equal(false);
 
           customElement.$.input.removeEventListener('mousedown', preventDefaultListener);
         });

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -125,6 +125,7 @@ This program is available under Apache License Version 2.0, available at https:/
       if (this.autofocus && !this.focused) {
         window.requestAnimationFrame(() => {
           this._focus();
+          this._setFocused(true);
           this.setAttribute('focus-ring', '');
         });
       }

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -57,6 +57,7 @@ This program is available under Apache License Version 2.0, available at https:/
          */
         focused: {
           type: Boolean,
+          value: false,
           notify: true,
           readOnly: true,
           observer: '_focusedChanged',
@@ -92,15 +93,30 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
-      this.addEventListener('blur', () => this._setFocused(false));
+      this.addEventListener('focusin', (e) => {
+        if (e.composedPath()[0] === this.focusElement) {
+          this._setFocused(true);
+        }
+      });
+      this.addEventListener('focusout', (e) => {
+        if (e.composedPath()[0] === this.focusElement) {
+          this._setFocused(false);
+        }
+      });
 
-      this.addEventListener('mousedown', e => !e.defaultPrevented && this._focus(e));
+      this.addEventListener('mousedown', e => {
+        if (!e.defaultPrevented) {
+          this._focus(e);
+          e.preventDefault();
+        }
+      });
 
       this.addEventListener('keydown', e => {
         if (e.shiftKey && e.keyCode === 9) {
           // Flag is checked in _focus event handler.
           this._isShiftTabbing = true;
           HTMLElement.prototype.focus.apply(this);
+          this._setFocused(false);
           // Event handling in IE is asynchronous and the flag is removed asynchronously as well
           setTimeout(() => this._isShiftTabbing = false, 0);
         }
@@ -163,7 +179,6 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      this._setFocused(!this.disabled);
       this.focusElement.focus();
     }
 
@@ -173,6 +188,7 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     focus() {
       this.focusElement.focus();
+      this._setFocused(true);
     }
 
     /**
@@ -182,12 +198,12 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     blur() {
       this.focusElement.blur();
+      this._setFocused(false);
     }
 
     _disabledChanged(disabled) {
       this.focusElement.disabled = disabled;
       if (disabled) {
-        this._setFocused(false);
         this.blur();
         this._previousTabIndex = this.tabindex;
         this.tabindex = -1;

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -93,16 +93,8 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
-      this.addEventListener('focusin', (e) => {
-        if (e.composedPath()[0] === this.focusElement) {
-          this._setFocused(true);
-        }
-      });
-      this.addEventListener('focusout', (e) => {
-        if (e.composedPath()[0] === this.focusElement) {
-          this._setFocused(false);
-        }
-      });
+      this.addEventListener('focusin', e => e.composedPath()[0] === this.focusElement && this._setFocused(true));
+      this.addEventListener('focusout', e => e.composedPath()[0] === this.focusElement && this._setFocused(false));
 
       this.addEventListener('mousedown', e => {
         if (!e.defaultPrevented) {


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-combo-box/issues/506

Listening to `focusin` and `focusout` event, controlling focused property with `_setFocused`, add default `false` value to focused

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/18)
<!-- Reviewable:end -->
