### PR TITLE
Not focusing when disabled

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -205,6 +205,12 @@
           expect(customElement.focused).to.be.true;
         });
 
+        it('should not set focused attribute on focusin event dispatched when disabled', () => {
+          customElement.disabled = true;
+          focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
+          expect(customElement.focused).to.be.false;
+        });
+
         it('should not set focused attribute on host mousedown with default prevented', () => {
           const e = new CustomEvent('mousedown', {bubbles: true, cancelable: true, composed: true});
           const preventDefaultListener = (e) => e.preventDefault();

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -93,7 +93,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
-      this.addEventListener('focusin', e => e.composedPath()[0] === this.focusElement && this._setFocused(true));
+      this.addEventListener('focusin', e => e.composedPath()[0] === this.focusElement && !this.disabled && this._setFocused(true));
       this.addEventListener('focusout', e => e.composedPath()[0] === this.focusElement && this._setFocused(false));
 
       this.addEventListener('mousedown', e => {
@@ -114,7 +114,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
-      if (this.autofocus && !this.focused) {
+      if (this.autofocus && !this.focused && !this.disabled) {
         window.requestAnimationFrame(() => {
           this._focus();
           this._setFocused(true);

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -180,6 +180,10 @@ This program is available under Apache License Version 2.0, available at https:/
      * @private
      */
     focus() {
+      if (this.disabled) {
+        return;
+      }
+
       this.focusElement.focus();
       this._setFocused(true);
     }


### PR DESCRIPTION
Not focusing the `focusElement` and not setting `focused` attribute when disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/19)
<!-- Reviewable:end -->
