### PR TITLE
Hotfix: set focus-ring when tabbing

### DIFF
--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -173,6 +173,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       this.focusElement.focus();
+      this._setFocused(true);
     }
 
     /**


### PR DESCRIPTION
Hotfix: set focus-ring and `focused` attribute when tabbing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/20)
<!-- Reviewable:end -->
