### PR TITLE
Fix/check focus element

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -11,6 +11,27 @@
 
 <body>
 
+  <dom-module id="test-wrapper">
+    <template>
+      <test-element id="testElement"></test-element>
+    </template>
+    <script>
+      document.addEventListener('WebComponentsReady', () => {
+        class TestWrapper extends Vaadin.ControlStateMixin(Polymer.Element) {
+          static get is() {
+            return 'test-wrapper';
+          }
+
+          get focusElement() {
+            return this.$.testElement;
+          }
+        }
+
+        customElements.define('test-wrapper', TestWrapper);
+      });
+    </script>
+  </dom-module>
+
   <dom-module id="test-element">
     <template>
       <input id="input">
@@ -36,6 +57,12 @@
   <test-fixture id="default">
     <template>
       <test-element></test-element>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="wrapper">
+    <template>
+      <test-wrapper></test-wrapper>
     </template>
   </test-fixture>
 
@@ -247,6 +274,29 @@
           expect(customElement._focus.callCount).to.eql(1);
         });
       });
+    });
+
+    describe('focused with nested focusable elements', () => {
+      let customElementWrapper, customElement, focusElement;
+
+      beforeEach(() => {
+        customElementWrapper = fixture('wrapper');
+        customElement = customElementWrapper.focusElement;
+        focusElement = customElement.focusElement;
+      });
+
+      it('should set focused attribute on focusin event dispatched from an element inside focusElement', () => {
+        focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
+        expect(customElementWrapper.focused).to.be.true;
+      });
+
+      it('should remove focused attribute on focusout event dispatched from an element inside focusElement', () => {
+        focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
+        expect(customElementWrapper.focused).to.be.true;
+        focusElement.dispatchEvent(new CustomEvent('focusout', {composed: true, bubbles: true}));
+        expect(customElementWrapper.focused).to.be.false;
+      });
+
     });
   </script>
 </body>

--- a/test/control-state.html
+++ b/test/control-state.html
@@ -14,6 +14,7 @@
   <dom-module id="test-element">
     <template>
       <input id="input">
+      <input id="secondInput">
     </template>
     <script>
       document.addEventListener('WebComponentsReady', () => {
@@ -46,12 +47,13 @@
 
   <script>
     describe('control-state behavior', () => {
-      var customElement, focusElement;
+      var customElement, focusElement, secondFocusableElement;
 
       beforeEach(() => {
         customElement = fixture('default');
         // Need the shadow dom be rendered before getting the internal element reference
         focusElement = customElement.focusElement;
+        secondFocusableElement = customElement.$.secondInput;
       });
 
       describe('tabindex', () => {
@@ -208,6 +210,11 @@
         it('should not set focused attribute on focusin event dispatched when disabled', () => {
           customElement.disabled = true;
           focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
+          expect(customElement.focused).to.be.false;
+        });
+
+        it('should not set focused attribute on focusin event dispatched from other focusable element inside component', () => {
+          secondFocusableElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
           expect(customElement.focused).to.be.false;
         });
 

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -93,8 +93,8 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
-      this.addEventListener('focusin', e => e.composedPath()[0] === this.focusElement && !this.disabled && this._setFocused(true));
-      this.addEventListener('focusout', e => e.composedPath()[0] === this.focusElement && this._setFocused(false));
+      this.addEventListener('focusin', e => e.composedPath().indexOf(this.focusElement) !== -1 && !this.disabled && this._setFocused(true));
+      this.addEventListener('focusout', e => e.composedPath().indexOf(this.focusElement) !== -1 && this._setFocused(false));
 
       this.addEventListener('mousedown', e => {
         if (!e.defaultPrevented) {


### PR DESCRIPTION
Checking if the `focusElement` actually exists in composed path.
Add test for specific use-case when there is one more focusable element inside component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/21)
<!-- Reviewable:end -->
