### PR TITLE
Fix mouse selection and focused state

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -183,16 +183,33 @@
         });
 
         it('should refocus the field', (done) => {
-          customElement.dispatchEvent(new CustomEvent('focus'));
+          customElement.dispatchEvent(new CustomEvent('focusin'));
           MockInteractions.keyDownOn(customElement, 9, 'shift');
 
           // Shift + Tab disables refocusing temporarily, normal behaviour is restored asynchronously.
           setTimeout(() => {
             var spy = sinon.spy(focusElement, 'focus');
-            customElement.dispatchEvent(new CustomEvent('focus'));
+            customElement.dispatchEvent(new CustomEvent('focusin'));
             expect(spy.called).to.be.true;
             done();
           }, 0);
+        });
+
+        it('should add focusin and focusout listeners before super.ready', () => {
+          class TestSuperClass {
+            constructor() {
+              this.addEventListener = sinon.stub();
+            }
+            ready() {
+              // The listneres should have been added by now
+              expect(this.addEventListener.calledWith('focusin')).to.be.true;
+              expect(this.addEventListener.calledWith('focusout')).to.be.true;
+            }
+          }
+
+          class TestClass extends Vaadin.ControlStateMixin(TestSuperClass) {}
+          const instance = new TestClass();
+          instance.ready();
         });
       });
 
@@ -245,18 +262,6 @@
           expect(customElement.focused).to.be.false;
         });
 
-        it('should not set focused attribute on host mousedown with default prevented', () => {
-          const e = new CustomEvent('mousedown', {bubbles: true, cancelable: true, composed: true});
-          const preventDefaultListener = (e) => e.preventDefault();
-          customElement.$.input.addEventListener('mousedown', preventDefaultListener);
-
-          customElement.$.input.dispatchEvent(e);
-
-          expect(customElement.focused).to.be.false;
-
-          customElement.$.input.removeEventListener('mousedown', preventDefaultListener);
-        });
-
         it('should have focused and focus-ring set', done => {
           customElement = fixture('autofocus');
 
@@ -265,13 +270,6 @@
             expect(customElement.hasAttribute('focus-ring')).to.be.true;
             done();
           });
-        });
-
-        it('should focus an element only once on mousedown', () => {
-          customElement._focus = sinon.spy();
-          customElement.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
-          customElement.dispatchEvent(new CustomEvent('focus', {bubbles: true, composed: true}));
-          expect(customElement._focus.callCount).to.eql(1);
         });
       });
     });

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -85,23 +85,20 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     ready() {
+      this.addEventListener('focusin', e => {
+        if (e.composedPath()[0] === this) {
+          this._focus(e);
+        } else if (e.composedPath().indexOf(this.focusElement) !== -1 && !this.disabled) {
+          this._setFocused(true);
+        }
+      });
+      this.addEventListener('focusout', e => this._setFocused(false));
+
+      // In super.ready() other 'focusin' and 'focusout' listeners might be
+      // added, so we call it after our own ones to ensure they execute first.
+      // Issue to watch out: when incorrect, <vaadin-combo-box> refocuses the
+      // input field on iOS after “Done” is pressed.
       super.ready();
-
-      this.addEventListener('focus', e => {
-        if (this._tabPressed) {
-          this._focus(e);
-        }
-      });
-
-      this.addEventListener('focusin', e => e.composedPath().indexOf(this.focusElement) !== -1 && !this.disabled && this._setFocused(true));
-      this.addEventListener('focusout', e => e.composedPath().indexOf(this.focusElement) !== -1 && this._setFocused(false));
-
-      this.addEventListener('mousedown', e => {
-        if (!e.defaultPrevented) {
-          this._focus(e);
-          e.preventDefault();
-        }
-      });
 
       this.addEventListener('keydown', e => {
         if (e.shiftKey && e.keyCode === 9) {


### PR DESCRIPTION
Fixes #22
Fixes vaadin/vaadin-combo-box#506

- Remove preventDefault for mousedown and mousedown listener altogether,
  rely on native focusing on mousedown instead.
- Propagate focus to `focusElement` on `focusin` of the host
- Always clear the `focused` state on focusout.
- Ensure `focusin` and `focusout` are listened before superclass
  listens for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/24)
<!-- Reviewable:end -->
