### PR TITLE
When keydown event is default prevented, should ignore it

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -166,9 +166,14 @@
         });
 
         it('should skip setting _isShiftTabbing if event is defaultPrevented', () => {
-          const event = MockInteractions.keyboardEventFor('keydown', 9, 'shift');
-          event.preventDefault();
-          customElement.dispatchEvent(event);
+          const evt = MockInteractions.keyboardEventFor('keydown', 9, 'shift');
+          // In Edge just calling preventDefault() does not work because of the polyfilled dispatchEvent
+          Object.defineProperty(evt, 'defaultPrevented', {
+            get() {
+              return true;
+            }
+          });
+          customElement.dispatchEvent(evt);
           expect(customElement._isShiftTabbing).not.to.be.ok;
         });
 

--- a/test/control-state.html
+++ b/test/control-state.html
@@ -159,6 +159,19 @@
           expect(customElement._tabPressed).to.be.false;
         });
 
+        it('should set _isShiftTabbing when pressing shift-tab', () => {
+          const event = MockInteractions.keyboardEventFor('keydown', 9, 'shift');
+          customElement.dispatchEvent(event);
+          expect(customElement._isShiftTabbing).to.be.true;
+        });
+
+        it('should skip setting _isShiftTabbing if event is defaultPrevented', () => {
+          const event = MockInteractions.keyboardEventFor('keydown', 9, 'shift');
+          event.preventDefault();
+          customElement.dispatchEvent(event);
+          expect(customElement._isShiftTabbing).not.to.be.ok;
+        });
+
         it('should not change _tabPressed on any other key except TAB', () => {
           MockInteractions.keyDownOn(document.body, 65);
           expect(customElement._tabPressed).to.be.false;

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -104,15 +104,13 @@ This program is available under Apache License Version 2.0, available at https:/
       super.ready();
 
       this.addEventListener('keydown', e => {
-        if (!e.defaultPrevented) {
-          if (e.shiftKey && e.keyCode === 9) {
-            // Flag is checked in _focus event handler.
-            this._isShiftTabbing = true;
-            HTMLElement.prototype.focus.apply(this);
-            this._setFocused(false);
-            // Event handling in IE is asynchronous and the flag is removed asynchronously as well
-            setTimeout(() => this._isShiftTabbing = false, 0);
-          }
+        if (!e.defaultPrevented && e.shiftKey && e.keyCode === 9) {
+          // Flag is checked in _focus event handler.
+          this._isShiftTabbing = true;
+          HTMLElement.prototype.focus.apply(this);
+          this._setFocused(false);
+          // Event handling in IE is asynchronous and the flag is removed asynchronously as well
+          setTimeout(() => this._isShiftTabbing = false, 0);
         }
       });
 

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -104,13 +104,15 @@ This program is available under Apache License Version 2.0, available at https:/
       super.ready();
 
       this.addEventListener('keydown', e => {
-        if (e.shiftKey && e.keyCode === 9) {
-          // Flag is checked in _focus event handler.
-          this._isShiftTabbing = true;
-          HTMLElement.prototype.focus.apply(this);
-          this._setFocused(false);
-          // Event handling in IE is asynchronous and the flag is removed asynchronously as well
-          setTimeout(() => this._isShiftTabbing = false, 0);
+        if (!e.defaultPrevented) {
+          if (e.shiftKey && e.keyCode === 9) {
+            // Flag is checked in _focus event handler.
+            this._isShiftTabbing = true;
+            HTMLElement.prototype.focus.apply(this);
+            this._setFocused(false);
+            // Event handling in IE is asynchronous and the flag is removed asynchronously as well
+            setTimeout(() => this._isShiftTabbing = false, 0);
+          }
         }
       });
 

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -6,7 +6,7 @@ module.exports = {
       'macOS 10.12/iphone@10.3',
       'macOS 10.12/ipad@10.3',
       'Windows 10/microsoftedge@15',
-      'macOS 10.12/safari@10.0'
+      'macOS 10.12/safari@11.0'
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-date-picker/issues/477


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/28)
<!-- Reviewable:end -->
