### PR TITLE
Remove focused state when disconnected from the DOM

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -289,6 +289,13 @@
             done();
           });
         });
+
+        it('should remove focused attribute when disconnected from the DOM', () => {
+          focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
+          customElement.parentNode.removeChild(customElement);
+          window.ShadyDOM && window.ShadyDOM.flush();
+          expect(customElement.hasAttribute('focused')).to.be.false;
+        });
       });
     });
 

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -131,6 +131,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
       document.body.removeEventListener('keydown', this._boundKeydownListener, true);
       document.body.removeEventListener('keyup', this._boundKeyupListener, true);
+
+      // in non-Chrome browsers, blur does not fire on the element when it is disconnected.
+      // reproducible in `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
+      if (this.hasAttribute('focused')) {
+        this._setFocused(false);
+      }
     }
 
     _setFocused(focused) {


### PR DESCRIPTION
Connected to vaadin/vaadin-date-picker#505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/34)
<!-- Reviewable:end -->
