### PR TITLE
Don't focus element that hasn't yet been attached to the DOM

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -25,7 +25,7 @@
           }
 
           get focusElement() {
-            return this.$.testElement;
+            return this.shadowRoot && this.$.testElement;
           }
         }
 
@@ -293,6 +293,10 @@
             expect(customElement.hasAttribute('focus-ring')).to.be.true;
             done();
           });
+        });
+
+        it('should not throw an error when using focus() to a newly created method', () => {
+          document.createElement('test-wrapper').focus();
         });
 
         it('should remove focused attribute when disconnected from the DOM', () => {

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -205,7 +205,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * @private
      */
     focus() {
-      if (this.disabled) {
+      if (!this.focusElement || this.disabled) {
         return;
       }
 


### PR DESCRIPTION
Connects to https://github.com/vaadin/vaadin-text-field/issues/269

Based on https://github.com/vaadin/vaadin-control-state-mixin/pull/47

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/48)
<!-- Reviewable:end -->
