### PR TITLE
Workaround Firefox 63..65 tab focus issue

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -234,6 +234,28 @@
           const instance = document.createElement('test-listeners');
           instance.ready();
         });
+
+        it('should use a fake focus element on tab (firefox)', () => {
+          // Test the workaround for FF63-65 bug that causes the focus to get lost when
+          // blurring a slotted component with focusable shadow root content
+          // https://bugzilla.mozilla.org/show_bug.cgi?id=1528686
+          // TODO: Remove when safe
+          customElement.tabIndex = 2;
+          const shouldWorkaround = window.navigator.userAgent.indexOf('Firefox/63') > -1
+          || window.navigator.userAgent.indexOf('Firefox/64') > -1
+          || window.navigator.userAgent.indexOf('Firefox/65') > -1;
+
+          MockInteractions.keyDownOn(customElement, 9);
+          const fakeTarget = customElement.nextSibling;
+
+          expect(fakeTarget.localName === 'input').to.equal(!!shouldWorkaround);
+          if (shouldWorkaround) {
+            expect(fakeTarget.tabIndex).to.equal(2);
+            expect(fakeTarget.parentNode).to.be.ok;
+            fakeTarget.dispatchEvent(new CustomEvent('focusout'));
+            expect(fakeTarget.parentNode).not.to.be.ok;
+          }
+        });
       });
 
       describe('disabled', () => {

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -110,13 +110,36 @@ This program is available under Apache License Version 2.0, available at https:/
       this.shadowRoot.addEventListener('focusout', ensureEventComposed);
 
       this.addEventListener('keydown', e => {
-        if (!e.defaultPrevented && e.shiftKey && e.keyCode === 9) {
-          // Flag is checked in _focus event handler.
-          this._isShiftTabbing = true;
-          HTMLElement.prototype.focus.apply(this);
-          this._setFocused(false);
-          // Event handling in IE is asynchronous and the flag is removed asynchronously as well
-          setTimeout(() => this._isShiftTabbing = false, 0);
+        if (!e.defaultPrevented && e.keyCode === 9) {
+          if (e.shiftKey) {
+            // Flag is checked in _focus event handler.
+            this._isShiftTabbing = true;
+            HTMLElement.prototype.focus.apply(this);
+            this._setFocused(false);
+            // Event handling in IE is asynchronous and the flag is removed asynchronously as well
+            setTimeout(() => this._isShiftTabbing = false, 0);
+          } else {
+            // Workaround for FF63-65 bug that causes the focus to get lost when
+            // blurring a slotted component with focusable shadow root content
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1528686
+            // TODO: Remove when safe
+            const firefox = window.navigator.userAgent.match(/Firefox\/(\d\d\.\d)/);
+            if (firefox
+              && parseFloat(firefox[1]) >= 63
+              && parseFloat(firefox[1]) < 66
+              && this.parentNode
+              && this.nextSibling) {
+              const fakeTarget = document.createElement('input');
+              fakeTarget.style.position = 'absolute';
+              fakeTarget.style.opacity = 0;
+              fakeTarget.tabIndex = this.tabIndex;
+
+              this.parentNode.insertBefore(fakeTarget, this.nextSibling);
+              fakeTarget.focus();
+              fakeTarget.addEventListener('focusout', () => this.parentNode.removeChild(fakeTarget));
+            }
+          }
+
         }
       });
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-text-field/issues/318
Fixes https://github.com/vaadin/flow/issues/4682

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/52)
<!-- Reviewable:end -->
