### PR TITLE
refactor: remove unnecessary expression

### DIFF
--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -143,7 +143,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
-      if (this.autofocus && !this.focused && !this.disabled) {
+      if (this.autofocus && !this.disabled) {
         window.requestAnimationFrame(() => {
           this._focus();
           this._setFocused(true);


### PR DESCRIPTION
There is no `focused` property anymore so `!this.focused` is always true and it also doesn't need to be checked here.

For context see commits:
- https://github.com/vaadin/vaadin-control-state-mixin/commit/de55f687f1b64497c619a3d5ef097918a3a54f32 (remove `focused` property)
- https://github.com/vaadin/vaadin-control-state-mixin/commit/f98fe7285a22ce4d18488b50f167c6458c472211 (bring back `focused` property as deprecated)
- https://github.com/vaadin/vaadin-control-state-mixin/commit/873ea1dbb7e8bd85e9e561760cf2a261c7c4e1eb#diff-9135a9a71f09d1f970e0eaab49266bc0 (remove deprecated `focused` property)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-control-state-mixin/54)
<!-- Reviewable:end -->
