### PR TITLE
chore: prepare for TS defs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: "66.0"
+  firefox: latest
   chrome: stable
 
 before_script:

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,7 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "demo/**/*",
+    "test/**/*"
+  ]
+}

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -14,6 +14,7 @@ This program is available under Apache License Version 2.0, available at https:/
    * A private mixin to avoid problems with dynamic properties and Polymer Analyzer.
    * No need to expose these properties in the API docs.
    * @polymerMixin
+   * @private
    */
   const TabIndexMixin = superClass => class VaadinTabIndexMixin extends superClass {
     static get properties() {
@@ -59,6 +60,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Stores the previous value of tabindex attribute of the disabled element
+         * @private
          */
         _previousTabIndex: {
           type: Number
@@ -73,12 +75,18 @@ This program is available under Apache License Version 2.0, available at https:/
           reflectToAttribute: true
         },
 
+        /**
+         * @private
+         */
         _isShiftTabbing: {
           type: Boolean
         }
       };
     }
 
+    /**
+     * @protected
+     */
     ready() {
       this.addEventListener('focusin', e => {
         if (e.composedPath()[0] === this) {
@@ -181,6 +189,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /**
+     * @param {boolean} focused
+     * @protected
+     */
     _setFocused(focused) {
       if (focused) {
         this.setAttribute('focused', '');
@@ -197,10 +209,17 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /**
+     * @param {KeyboardEvent} e
+     * @private
+     */
     _bodyKeydownListener(e) {
       this._tabPressed = e.keyCode === 9;
     }
 
+    /**
+     * @private
+     */
     _bodyKeyupListener() {
       this._tabPressed = false;
     }
@@ -208,13 +227,17 @@ This program is available under Apache License Version 2.0, available at https:/
     /**
      * Any element extending this mixin is required to implement this getter.
      * It returns the actual focusable element in the component.
+     * @return {HTMLElement}
      */
     get focusElement() {
       window.console.warn(`Please implement the 'focusElement' property in <${this.localName}>`);
       return this;
     }
 
-    _focus(e) {
+    /**
+     * @private
+     */
+    _focus() {
       if (this._isShiftTabbing) {
         return;
       }
@@ -246,6 +269,10 @@ This program is available under Apache License Version 2.0, available at https:/
       this._setFocused(false);
     }
 
+    /**
+     * @param {boolean} disabled
+     * @private
+     */
     _disabledChanged(disabled) {
       this.focusElement.disabled = disabled;
       if (disabled) {
@@ -261,6 +288,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /**
+     * @param {number | null | undefined} tabindex
+     * @private
+     */
     _tabindexChanged(tabindex) {
       if (tabindex !== undefined) {
         this.focusElement.tabIndex = tabindex;


### PR DESCRIPTION
Fixes #57 

The result of running `magi p3-convert` locally (without auto-generated comments in `.d.ts`):

```
> @vaadin/vaadin-control-state-mixin@2.1.3 generate-typings /Users/sergey/vaadin/vaadin-control-state-mixin
> gen-typescript-declarations --outDir . --verify

Loading config from "gen-tsd.json".
Writing type declarations to /Users/sergey/vaadin/vaadin-control-state-mixin
Verifying type declarations
Compilation successful
```

## vaadin-control-state-mixin.d.ts

```ts
export {ControlStateMixin};


/**
 * Polymer.IronControlState is not a proper 2.0 class, also, its tabindex
 * implementation fails in the shadow dom, so we have this for vaadin elements.
 */
declare function ControlStateMixin<T extends new (...args: any[]) => {}>(base: T): T & ControlStateMixinConstructor;

interface ControlStateMixinConstructor {
  new(...args: any[]): ControlStateMixin;
}

export {ControlStateMixinConstructor};

interface ControlStateMixin {

  /**
   * Any element extending this mixin is required to implement this getter.
   * It returns the actual focusable element in the component.
   */
  readonly focusElement: HTMLElement|null;

  /**
   * Specify that this control should have input focus when the page loads.
   */
  autofocus: boolean|null|undefined;

  /**
   * If true, the user cannot interact with this element.
   */
  disabled: boolean|null|undefined;
  ready(): void;
  connectedCallback(): void;
  disconnectedCallback(): void;
  _setFocused(focused: boolean): void;
  click(): void;
}
```

Note, `_setFocused` is not marked as `@private` because of overriding in [vaadin-select](https://github.com/vaadin/vaadin-select/blob/ae330b856a77533703279d92c9d7e41137313519/src/vaadin-select.html#L630-L633).