### PR TITLE
fix: make internal focus method protected

### DIFF
--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -235,7 +235,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /**
-     * @private
+     * @protected
      */
     _focus() {
       if (!this.focusElement || this._isShiftTabbing) {


### PR DESCRIPTION
This is needed to mitigate the error when converting `vaadin-date-picker`:

```
class DatePickerElement extends
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning [overriding-private] - Overriding private member '_focus' inherited from ControlStateMixin
```