### PR TITLE
fix: Only run _focus if focus is received from outside

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -311,6 +311,20 @@
           expect(customElement.hasAttribute('focused')).to.be.true;
         });
 
+        it('not focus if the focus is not received from outside', () => {
+          const child = document.createElement('div');
+          customElement.appendChild(child);
+
+          const event = new CustomEvent('focusin', {
+            composed: true,
+            bubbles: true
+          });
+          event.relatedTarget = child;
+          customElement.dispatchEvent(event);
+
+          expect(customElement.hasAttribute('focused')).to.be.false;
+        });
+
         it('should not set focused attribute on focusin event dispatched when disabled', () => {
           customElement.disabled = true;
           focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -90,7 +90,10 @@ This program is available under Apache License Version 2.0, available at https:/
     ready() {
       this.addEventListener('focusin', e => {
         if (e.composedPath()[0] === this) {
-          this._focus();
+          // Only focus if the focus is received from somewhere outside
+          if (!this.contains(e.relatedTarget)) {
+            this._focus();
+          }
         } else if (e.composedPath().indexOf(this.focusElement) !== -1 && !this.disabled) {
           this._setFocused(true);
         }


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-details-flow/issues/44

When content from a Web Component's light DOM is slotted inside of a focusable element (in the shadow root), it seems that on the content click, Chrome focuses the next focusable parent instead of the focusable element/Web Component. On Firefox/Safari, the focus remains on the Web Component instead.

Here's an isolated example: https://jsbin.com/kuzayihuni/edit

Regarding the issue: Details extends control-state-mixin, which makes it programmatically focus the "summary" element on the `focusin` event, causing the jump in this case (on Chrome). One potential workaround (this PR) could be to make the control-state-mixin to handle the events only when the focus is received from somewhere outside.
