### PR TITLE
Fixes #56 - Use focus ring if not focused with mouse

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -138,7 +138,7 @@
         });
       });
 
-      describe('_tabPressed and focus-ring', () => {
+      describe('_isMouseDown and focus-ring', () => {
         var focusin = () => {
           focusElement.dispatchEvent(new CustomEvent('focusin', {composed: true, bubbles: true}));
         };
@@ -147,18 +147,18 @@
           focusElement.dispatchEvent(new CustomEvent('focusout', {composed: true, bubbles: true}));
         };
 
-        it('should set and unset _tabPressed when press TAB', () => {
+        it('_isMouseDown should be false when press TAB', () => {
           MockInteractions.keyDownOn(document.body, 9);
-          expect(customElement._tabPressed).to.be.true;
+          expect(customElement._isMouseDown).to.be.false;
           MockInteractions.keyUpOn(document.body, 9);
-          expect(customElement._tabPressed).to.be.false;
+          expect(customElement._isMouseDown).to.be.false;
         });
 
-        it('should set and unset _tabPressed when press SHIFT+TAB', () => {
+        it('_isMouseDown should be false when press SHIFT+TAB', () => {
           MockInteractions.keyDownOn(document.body, 9, 'shift');
-          expect(customElement._tabPressed).to.be.true;
+          expect(customElement._isMouseDown).to.be.false;
           MockInteractions.keyUpOn(document.body, 9, 'shift');
-          expect(customElement._tabPressed).to.be.false;
+          expect(customElement._isMouseDown).to.be.false;
         });
 
         it('should set _isShiftTabbing when pressing shift-tab', () => {
@@ -177,13 +177,6 @@
           });
           customElement.dispatchEvent(evt);
           expect(customElement._isShiftTabbing).not.to.be.ok;
-        });
-
-        it('should not change _tabPressed on any other key except TAB', () => {
-          MockInteractions.keyDownOn(document.body, 65);
-          expect(customElement._tabPressed).to.be.false;
-          MockInteractions.keyUpOn(document.body, 65);
-          expect(customElement._tabPressed).to.be.false;
         });
 
         it('should set the focus-ring attribute when TAB is pressed and focus is received', () => {

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -75,6 +75,14 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _isShiftTabbing: {
           type: Boolean
+        },
+
+        /**
+         * Property used to prevent focus ring when focused with mouse.
+         */
+        _isMouseDown: {
+          type: Boolean,
+          value: false
         }
       };
     }
@@ -143,6 +151,16 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       });
 
+      // #56 Listening mouse events to know when to not add the focus ring
+      this.addEventListener('mousedown', e => {
+        this._isMouseDown = true;
+        const mouseUpListener = () => {
+          this._isMouseDown = false;
+          document.removeEventListener('mouseup', mouseUpListener);
+        };
+        document.addEventListener('mouseup', mouseUpListener);
+      });
+
       if (this.autofocus && !this.disabled) {
         window.requestAnimationFrame(() => {
           this._focus();
@@ -150,9 +168,6 @@ This program is available under Apache License Version 2.0, available at https:/
           this.setAttribute('focus-ring', '');
         });
       }
-
-      this._boundKeydownListener = this._bodyKeydownListener.bind(this);
-      this._boundKeyupListener = this._bodyKeyupListener.bind(this);
     }
 
     /**
@@ -160,9 +175,6 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     connectedCallback() {
       super.connectedCallback();
-
-      document.body.addEventListener('keydown', this._boundKeydownListener, true);
-      document.body.addEventListener('keyup', this._boundKeyupListener, true);
     }
 
     /**
@@ -170,9 +182,6 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     disconnectedCallback() {
       super.disconnectedCallback();
-
-      document.body.removeEventListener('keydown', this._boundKeydownListener, true);
-      document.body.removeEventListener('keyup', this._boundKeyupListener, true);
 
       // in non-Chrome browsers, blur does not fire on the element when it is disconnected.
       // reproducible in `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
@@ -190,19 +199,11 @@ This program is available under Apache License Version 2.0, available at https:/
 
       // focus-ring is true when the element was focused from the keyboard.
       // Focus Ring [A11ycasts]: https://youtu.be/ilj2P5-5CjI
-      if (focused && this._tabPressed) {
+      if (focused && !this._isMouseDown) {
         this.setAttribute('focus-ring', '');
       } else {
         this.removeAttribute('focus-ring');
       }
-    }
-
-    _bodyKeydownListener(e) {
-      this._tabPressed = e.keyCode === 9;
-    }
-
-    _bodyKeyupListener() {
-      this._tabPressed = false;
     }
 
     /**


### PR DESCRIPTION
This should make components based on 2.1 branch (Vaadin 14) to handle focusring correctly. And only not show it when component is focused by mouse. This also will fix the #50, as focusing my command is not a mouse event. As far as I know LitElement based versions did not have this issue, so PR is targeting 2.1 (used by Vaadin 14)