### PR TITLE
refactor: expose keyboardActive flag

### DIFF
--- a/test/control-state.html
+++ b/test/control-state.html
@@ -188,6 +188,17 @@
           expect(customElement.hasAttribute('focus-ring')).to.be.false;
         });
 
+        it('should initialize keyboardActive to false', () => {
+          expect(customElement._keyboardActive).to.be.false;
+        });
+
+        it('should update keyboardActive on keydown and mousedown', () => {
+          MockInteractions.keyDownOn(document.body, 9);
+          expect(customElement._keyboardActive).to.be.true;
+          MockInteractions.down(document.body);
+          expect(customElement._keyboardActive).to.be.false;
+        });
+
         it('should refocus the field', (done) => {
           customElement.dispatchEvent(new CustomEvent('focusin'));
           MockInteractions.keyDownOn(customElement, 9, 'shift');

--- a/vaadin-control-state-mixin.html
+++ b/vaadin-control-state-mixin.html
@@ -109,6 +109,14 @@ This program is available under Apache License Version 2.0, available at https:/
 
     /**
      * @protected
+     * @return {boolean}
+     */
+    get _keyboardActive() {
+      return keyboardActive;
+    }
+
+    /**
+     * @protected
      */
     ready() {
       this.addEventListener('focusin', e => {


### PR DESCRIPTION
## Description

Exposes the `keyboardActive` flag in order to enable overriding focus behavior in sub-classes.

Part of back-porting https://github.com/vaadin/web-components/pull/3565
